### PR TITLE
Issue 13 serving assets from device

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -8,10 +8,14 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 
+[platformio]
+data_dir = $PROJECT_DIR\src\assets
+
 [env:huzzah]
 platform = espressif8266
 board = huzzah
 framework = arduino
+board_build.filesystem = littlefs
 monitor_speed = 115200
 lib_deps = 
 	fastled/FastLED@^3.3.3
@@ -20,6 +24,7 @@ lib_deps =
 [env:nodemcuv2]
 platform = espressif8266
 board = nodemcuv2
+board_build.filesystem = littlefs
 monitor_speed = 115200
 framework = arduino
 lib_deps = 

--- a/readme.md
+++ b/readme.md
@@ -14,5 +14,10 @@ To get started copy `include/env.dist.h` to `include/env.h` and make sure to pop
 
 Also, you may need to add and set a new env in the platform.io file for whatever board you are using locally
 
+#### Bundling and writing assets
+
+To write the assets folder to device, open the platform io command line `ctrl + shift + p` -> `Open PlatformIO core CLI` and rrun `pio run -t uploadfs`
+
 #### Hardware
 For this project you'll need somne kind of ESP8266 based or compatible microcontroller (Adafruit Huzzah or NodeMCU for instance), as well as WS2812B leds/strips. Refer to [this adafruit guide](https://learn.adafruit.com/adafruit-neopixel-uberguide/basic-connections) for wiring informtation.
+

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -87,6 +87,7 @@ String getContentType(String filename) { // convert the file extension to the MI
   else if (filename.endsWith(".css")) return "text/css";
   else if (filename.endsWith(".js")) return "application/javascript";
   else if (filename.endsWith(".ico")) return "image/x-icon";
+  else if (filename.endsWith(".svg")) return "image/svg+xml";
   return "text/plain";
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -35,6 +35,7 @@
 #include <env.h>
 #include <ledExample.h>
 #include <lightingManager.h>
+#include <LittleFS.h>
 
 ESP8266WebServer server ( 80 );
 
@@ -44,73 +45,6 @@ const int led = 13;
 const bool exampleLeds = true;
 
 LightingManager lightManager = LightingManager();
-
-void handleRoot() {
-	digitalWrite ( led, 1 );
-	char temp[400];
-	int sec = millis() / 1000;
-	int min = sec / 60;
-	int hr = min / 60;
-
-	snprintf ( temp, 400,
-
-"<html>\
-  <head>\
-    <meta http-equiv='refresh' content='5'/>\
-    <title>ESP8266 Demo</title>\
-    <style>\
-      body { background-color: #cccccc; font-family: Arial, Helvetica, Sans-Serif; Color: #000088; }\
-    </style>\
-  </head>\
-  <body>\
-    <h1>Hello from ESP8266!</h1>\
-    <p>Uptime: %02d:%02d:%02d</p>\
-    <img src=\"/test.svg\" />\
-  </body>\
-</html>",
-
-		hr, min % 60, sec % 60
-	);
-	server.send ( 200, "text/html", temp );
-	digitalWrite ( led, 0 );
-}
-
-void handleNotFound() {
-	digitalWrite ( led, 1 );
-	String message = "File Not Found\n\n";
-	message += "URI: ";
-	message += server.uri();
-	message += "\nMethod: ";
-	message += ( server.method() == HTTP_GET ) ? "GET" : "POST";
-	message += "\nArguments: ";
-	message += server.args();
-	message += "\n";
-
-	for ( uint8_t i = 0; i < server.args(); i++ ) {
-		message += " " + server.argName ( i ) + ": " + server.arg ( i ) + "\n";
-	}
-
-	server.send ( 404, "text/plain", message );
-	digitalWrite ( led, 0 );
-}
-
-void drawGraph() {
-	String out = "";
-	char temp[100];
-	out += "<svg xmlns=\"http://www.w3.org/2000/svg\" version=\"1.1\" width=\"400\" height=\"150\">\n";
- 	out += "<rect width=\"400\" height=\"150\" fill=\"rgb(250, 230, 210)\" stroke-width=\"1\" stroke=\"rgb(0, 0, 0)\" />\n";
- 	out += "<g stroke=\"black\">\n";
- 	int y = rand() % 130;
- 	for (int x = 10; x < 390; x+= 10) {
- 		int y2 = rand() % 130;
- 		sprintf(temp, "<line x1=\"%d\" y1=\"%d\" x2=\"%d\" y2=\"%d\" stroke-width=\"1\" />\n", x, 140 - y, x + 10, 140 - y2);
- 		out += temp;
- 		y = y2;
- 	}
-	out += "</g>\n</svg>\n";
-
-	server.send ( 200, "image/svg+xml", out);
-}
 
 void handleLighting () {
 	HTTPMethod method = server.method();
@@ -148,6 +82,47 @@ void handleLighting () {
 	}
 }
 
+String getContentType(String filename) { // convert the file extension to the MIME type
+  if (filename.endsWith(".html")) return "text/html";
+  else if (filename.endsWith(".css")) return "text/css";
+  else if (filename.endsWith(".js")) return "application/javascript";
+  else if (filename.endsWith(".ico")) return "image/x-icon";
+  return "text/plain";
+}
+
+bool handleFileRead(String path) { // send the right file to the client (if it exists)
+  Serial.println("handleFileRead: " + path);
+  if (path.endsWith("/")) path += "index.html";         // If a folder is requested, send the index file
+  String contentType = getContentType(path);            // Get the MIME type
+  if (LittleFS.exists(path)) {                            // If the file exists
+    File file = LittleFS.open(path, "r");                 // Open it
+    size_t sent = server.streamFile(file, contentType); // And send it to the client
+    file.close();                                       // Then close the file again
+    return true;
+  }
+  Serial.println("\tFile Not Found");
+  return false;                                         // If the file doesn't exist, return false
+}
+
+void handleNotFound() {
+	digitalWrite ( led, 1 );
+	String message = "File Not Found\n\n";
+	message += "URI: ";
+	message += server.uri();
+	message += "\nMethod: ";
+	message += ( server.method() == HTTP_GET ) ? "GET" : "POST";
+	message += "\nArguments: ";
+	message += server.args();
+	message += "\n";
+
+	for ( uint8_t i = 0; i < server.args(); i++ ) {
+		message += " " + server.argName ( i ) + ": " + server.arg ( i ) + "\n";
+	}
+
+	server.send ( 404, "text/plain", message );
+	digitalWrite ( led, 0 );
+}
+
 void setup ( void ) {
 	ESP.wdtDisable();
 	pinMode ( led, OUTPUT );
@@ -171,13 +146,15 @@ void setup ( void ) {
 		Serial.println ( "MDNS responder started" );
 	}
 
-	server.on ( "/", handleRoot );
-	server.on ( "/test.svg", drawGraph );
-	server.on ( "/inline", []() {
-		server.send ( 200, "text/plain", "this works as well" );
-	} );
+	LittleFS.begin();
+
 	server.on ("/lighting", handleLighting );
-	server.onNotFound ( handleNotFound );
+	
+	server.onNotFound([]() {
+    if (!handleFileRead(server.uri()))
+      handleNotFound();
+  	});
+
 	server.begin();
 	Serial.println ( "HTTP server started" );
 	if(exampleLeds) {


### PR DESCRIPTION
Adds support to serve assets folder from the microcontroller. Used LittleFS instead of SPIFFS due to pending deprecation of spiffs.

Readme has info on how to write asserts to the device.

Also removed all old routes from the example project.

closes #13 